### PR TITLE
feat: expose WRS normalized scores in optimizer metrics API

### DIFF
--- a/src/redis/resources/ProviderConsumerOptimizerMetrics/ProviderConsumerOptimizerMetricsFull.ts
+++ b/src/redis/resources/ProviderConsumerOptimizerMetrics/ProviderConsumerOptimizerMetricsFull.ts
@@ -35,6 +35,12 @@ export interface ConsumerOptimizerMetricsFullByProviderItem {
         tier2: number;
         tier3: number;
     };
+    // WRS normalized scores (0-1, higher is better)
+    selection_availability: number;
+    selection_latency: number;
+    selection_sync: number;
+    selection_stake: number;
+    selection_composite: number;
 }
 
 export interface ConsumerOptimizerMetricsFullByProviderResponse {
@@ -115,6 +121,11 @@ export class ConsumerOptimizerMetricsFullByProviderResource extends RedisResourc
                 tier_chance_1_sum: aggregatedConsumerOptimizerMetrics.tier_chance_1_sum,
                 tier_chance_2_sum: aggregatedConsumerOptimizerMetrics.tier_chance_2_sum,
                 tier_chance_3_sum: aggregatedConsumerOptimizerMetrics.tier_chance_3_sum,
+                selection_availability_sum: aggregatedConsumerOptimizerMetrics.selection_availability_sum,
+                selection_latency_sum: aggregatedConsumerOptimizerMetrics.selection_latency_sum,
+                selection_sync_sum: aggregatedConsumerOptimizerMetrics.selection_sync_sum,
+                selection_stake_sum: aggregatedConsumerOptimizerMetrics.selection_stake_sum,
+                selection_composite_sum: aggregatedConsumerOptimizerMetrics.selection_composite_sum,
             })
                 .from(aggregatedConsumerOptimizerMetrics)
                 .where(and(
@@ -187,7 +198,17 @@ export class ConsumerOptimizerMetricsFullByProviderResource extends RedisResourc
                         Number(m.tier_chance_2_sum) / Number(m.tier_metrics_count) : 0,
                     tier3: (m.tier_metrics_count ?? 0) > 0 && m.tier_chance_3_sum != null ?
                         Number(m.tier_chance_3_sum) / Number(m.tier_metrics_count) : 0,
-                }
+                },
+                selection_availability: m.selection_availability_sum != null ?
+                    Number(m.selection_availability_sum) / Number(m.metrics_count) : 0,
+                selection_latency: m.selection_latency_sum != null ?
+                    Number(m.selection_latency_sum) / Number(m.metrics_count) : 0,
+                selection_sync: m.selection_sync_sum != null ?
+                    Number(m.selection_sync_sum) / Number(m.metrics_count) : 0,
+                selection_stake: m.selection_stake_sum != null ?
+                    Number(m.selection_stake_sum) / Number(m.metrics_count) : 0,
+                selection_composite: m.selection_composite_sum != null ?
+                    Number(m.selection_composite_sum) / Number(m.metrics_count) : 0,
             });
         }
 

--- a/src/redis/resources/spec/SpecConsumerOptimizerMetricsFull.ts
+++ b/src/redis/resources/spec/SpecConsumerOptimizerMetricsFull.ts
@@ -37,6 +37,12 @@ export interface ConsumerOptimizerMetricsFullBySpecItem {
         tier2: number;
         tier3: number;
     };
+    // WRS normalized scores (0-1, higher is better)
+    selection_availability: number;
+    selection_latency: number;
+    selection_sync: number;
+    selection_stake: number;
+    selection_composite: number;
 }
 
 export interface ConsumerOptimizerMetricsFullBySpecResponse {
@@ -116,6 +122,11 @@ export class ConsumerOptimizerMetricsFullBySpecResource extends RedisResourceBas
                 tier_chance_1_sum: aggregatedConsumerOptimizerMetrics.tier_chance_1_sum,
                 tier_chance_2_sum: aggregatedConsumerOptimizerMetrics.tier_chance_2_sum,
                 tier_chance_3_sum: aggregatedConsumerOptimizerMetrics.tier_chance_3_sum,
+                selection_availability_sum: aggregatedConsumerOptimizerMetrics.selection_availability_sum,
+                selection_latency_sum: aggregatedConsumerOptimizerMetrics.selection_latency_sum,
+                selection_sync_sum: aggregatedConsumerOptimizerMetrics.selection_sync_sum,
+                selection_stake_sum: aggregatedConsumerOptimizerMetrics.selection_stake_sum,
+                selection_composite_sum: aggregatedConsumerOptimizerMetrics.selection_composite_sum,
             })
                 .from(aggregatedConsumerOptimizerMetrics)
                 .where(and(
@@ -194,7 +205,17 @@ export class ConsumerOptimizerMetricsFullBySpecResource extends RedisResourceBas
                         Number(m.tier_chance_2_sum) / Number(m.tier_metrics_count) : 0,
                     tier3: (m.tier_metrics_count ?? 0) > 0 && m.tier_chance_3_sum != null ?
                         Number(m.tier_chance_3_sum) / Number(m.tier_metrics_count) : 0,
-                }
+                },
+                selection_availability: m.selection_availability_sum != null ?
+                    Number(m.selection_availability_sum) / Number(m.metrics_count) : 0,
+                selection_latency: m.selection_latency_sum != null ?
+                    Number(m.selection_latency_sum) / Number(m.metrics_count) : 0,
+                selection_sync: m.selection_sync_sum != null ?
+                    Number(m.selection_sync_sum) / Number(m.metrics_count) : 0,
+                selection_stake: m.selection_stake_sum != null ?
+                    Number(m.selection_stake_sum) / Number(m.metrics_count) : 0,
+                selection_composite: m.selection_composite_sum != null ?
+                    Number(m.selection_composite_sum) / Number(m.metrics_count) : 0,
             });
         }
 

--- a/src/schemas/relaysSchema.ts
+++ b/src/schemas/relaysSchema.ts
@@ -61,7 +61,14 @@ export const aggregatedConsumerOptimizerMetrics = pgTable('aggregated_consumer_o
   tier_chance_1_sum: numeric('tier_chance_1_sum'),
   tier_chance_2_sum: numeric('tier_chance_2_sum'),
   tier_chance_3_sum: numeric('tier_chance_3_sum'),
-  tier_metrics_count: integer('tier_metrics_count')
+  tier_metrics_count: integer('tier_metrics_count'),
+
+  // WRS normalized scores
+  selection_availability_sum: numeric('selection_availability_sum'),
+  selection_latency_sum: numeric('selection_latency_sum'),
+  selection_sync_sum: numeric('selection_sync_sum'),
+  selection_stake_sum: numeric('selection_stake_sum'),
+  selection_composite_sum: numeric('selection_composite_sum'),
 });
 
 export type AggregatedConsumerOptimizerMetrics = typeof aggregatedConsumerOptimizerMetrics.$inferSelect


### PR DESCRIPTION
## Summary
- Add 5 WRS normalized score columns to `aggregatedConsumerOptimizerMetrics` schema: `selection_availability_sum`, `selection_latency_sum`, `selection_sync_sum`, `selection_stake_sum`, `selection_composite_sum`
- Expose averaged WRS scores (sum / metrics_count) in the Full variants of optimizer metrics endpoints
- Depends on [lavanet/relayserver#8](https://github.com/lavanet/relayserver/pull/8) which captures these fields on ingestion

## Affected endpoints
- `GET /providerConsumerOptimizerMetricsFull/:addr` — new fields in response
- `GET /specConsumerOptimizerMetricsFull/:specId` — new fields in response

## New response fields
```json
{
  "selection_availability": 0.95,
  "selection_latency": 0.78,
  "selection_sync": 0.88,
  "selection_stake": 0.65,
  "selection_composite": 0.82
}
```

## Test plan
- [ ] Deploy relayserver PR first so WRS data starts flowing into DB
- [ ] Deploy jsinfo and verify new fields appear in Full endpoint responses
- [ ] Verify fields default to 0 for historical rows (before WRS data was captured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)