### PR TITLE
fix: add missing provider fields to fix TS build

### DIFF
--- a/src/redis/resources/ProviderConsumerOptimizerMetrics/ProviderConsumerOptimizerMetricsFull.ts
+++ b/src/redis/resources/ProviderConsumerOptimizerMetrics/ProviderConsumerOptimizerMetricsFull.ts
@@ -20,6 +20,8 @@ export interface ConsumerOptimizerMetricsFullByProviderItem {
     consumer_hostname: string;
     metrics_count: number;
     provider_stake: number;
+    provider: string;
+    provider_moniker: string;
     latency_score: number;
     availability_score: number;
     sync_score: number;
@@ -102,6 +104,7 @@ export class ConsumerOptimizerMetricsFullByProviderResource extends RedisResourc
 
         const metrics = await queryRelays(db =>
             db.select({
+                provider: aggregatedConsumerOptimizerMetrics.provider,
                 chain: aggregatedConsumerOptimizerMetrics.chain,
                 hourly_timestamp: aggregatedConsumerOptimizerMetrics.hourly_timestamp,
                 consumer: aggregatedConsumerOptimizerMetrics.consumer,
@@ -143,6 +146,7 @@ export class ConsumerOptimizerMetricsFullByProviderResource extends RedisResourc
         // });
 
         const validMetrics: ConsumerOptimizerMetricsFullByProviderItem[] = [];
+        const providerMoniker = await ProviderMonikerService.GetMonikerForProvider(provider) || provider;
 
         for (const m of metrics) {
             if (m.latency_score_sum === null ||
@@ -180,6 +184,8 @@ export class ConsumerOptimizerMetricsFullByProviderResource extends RedisResourc
                 consumer_hostname: m.consumer_hostname,
                 metrics_count: m.metrics_count,
                 provider_stake: m.provider_stake,
+                provider: m.provider || provider,
+                provider_moniker: providerMoniker,
                 latency_score: Number(m.latency_score_sum) / Number(m.metrics_count),
                 availability_score: Number(m.availability_score_sum) / Number(m.metrics_count),
                 sync_score: Number(m.sync_score_sum) / Number(m.metrics_count),


### PR DESCRIPTION
## Summary
- Add `provider` and `provider_moniker` to `ConsumerOptimizerMetricsFullByProviderItem` interface
- Select `provider` from DB and resolve moniker via `ProviderMonikerService`
- Fixes TS build error: `ConsumerOptimizerMetricsFullByProviderItem` was missing fields required by `MetricsItem`

## Test plan
- [x] `tsc --noEmit` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)