### PR TITLE
feat: add WRS selection metrics to standard spec endpoint

### DIFF
--- a/src/query/utils/querySpecOptimizerMetricsHandlerUtils.ts
+++ b/src/query/utils/querySpecOptimizerMetricsHandlerUtils.ts
@@ -478,7 +478,12 @@ export const AVAILABLE_METRICS = {
     sync_score: "Sync Score",
     generic_score: "Reputation Score",
     node_error_rate: "Error Rate",
-    entry_index: "Entry Index"
+    entry_index: "Entry Index",
+    selection_latency: "Latency Score",
+    selection_availability: "Availability Score",
+    selection_sync: "Sync Score",
+    selection_stake: "Stake Score",
+    selection_composite: "Composite Score"
 } as const;
 
 export const AVAILABLE_METRICS_FULL = {
@@ -491,11 +496,11 @@ export const AVAILABLE_METRICS_FULL = {
     provider_stake: "Provider Stake",
     metrics_count: "Metrics Count",
     epoch: "Epoch",
-    selection_availability: "Selection Availability",
-    selection_latency: "Selection Latency",
-    selection_sync: "Selection Sync",
-    selection_stake: "Selection Stake",
-    selection_composite: "Selection Composite"
+    selection_availability: "Availability Score",
+    selection_latency: "Latency Score",
+    selection_sync: "Sync Score",
+    selection_stake: "Stake Score",
+    selection_composite: "Composite Score"
 } as const;
 
 export interface MetricsResponse {


### PR DESCRIPTION
## Summary
- Adds `selection_latency`, `selection_availability`, `selection_sync`, `selection_stake`, `selection_composite` to `AVAILABLE_METRICS` so the standard (non-key) spec endpoint accepts them as valid metric choices
- Updates `AVAILABLE_METRICS_FULL` labels to use consistent terminology ("Latency Score" instead of "Selection Latency")
- No data fetching changes needed — the Redis resource and aggregation layer already compute and return these fields

## Test plan
- [ ] Verify `specConsumerOptimizerMetrics/:specId?metric=selection_composite` returns valid data
- [ ] Verify all 5 selection_* metrics are accepted without `?key=`
- [ ] Verify the full endpoint still works with the updated labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)